### PR TITLE
Fix/pagination - 현재상영작 / 개봉예정작 더보기 화면에서 페이지네이션 안되는 버그 해결

### DIFF
--- a/Film-in/Common/Data/DTO/Discover/DiscoverResponseDTO+Mapping.swift
+++ b/Film-in/Common/Data/DTO/Discover/DiscoverResponseDTO+Mapping.swift
@@ -28,9 +28,9 @@ extension DiscoverResponseDTO {
                 .map {
                     HomeMovie.Movie(
                         _id: $0.id,
-                        title: $0.title ?? "",
-                        poster: $0.posterPath ?? "",
-                        backdrop: $0.backdropPath ?? ""
+                        title: $0.title,
+                        poster: $0.posterPath,
+                        backdrop: $0.backdropPath
                     )
                 }
         )

--- a/Film-in/Common/Data/DTO/MovieSimilar/MovieSimilarResponseDTO+Mapping.swift
+++ b/Film-in/Common/Data/DTO/MovieSimilar/MovieSimilarResponseDTO+Mapping.swift
@@ -28,9 +28,9 @@ extension MovieSimilarResponseDTO {
                 .map {
                     MovieSimilar.Movie(
                         id: $0.id,
-                        title: $0.title ?? "",
-                        poster: $0.posterPath ?? "",
-                        backdrop: $0.backdropPath ?? ""
+                        title: $0.title,
+                        poster: $0.posterPath,
+                        backdrop: $0.backdropPath
                     )
                 }
         )
@@ -44,9 +44,9 @@ extension MovieSimilarResponseDTO {
                 .map {
                     HomeMovie.Movie(
                         _id: $0.id,
-                        title: $0.title ?? "",
-                        poster: $0.posterPath ?? "",
-                        backdrop: $0.backdropPath ?? ""
+                        title: $0.title,
+                        poster: $0.posterPath,
+                        backdrop: $0.backdropPath
                     )
                 }
         )

--- a/Film-in/Common/Data/DTO/NowPlaying/NowPlayingResponseDTO+Mapping.swift
+++ b/Film-in/Common/Data/DTO/NowPlaying/NowPlayingResponseDTO+Mapping.swift
@@ -11,13 +11,13 @@ struct NowPlayingResponseDTO: Decodable {
     let dates: PeriodResponseDTO
     let page: Int
     let results: [TMDBMovieResponseDTO]
-    let totalPages: Int
+    let totalPage: Int
     
     enum CodingKeys: String, CodingKey {
         case dates
         case page
         case results
-        case totalPages = "total_pages"
+        case totalPage = "total_pages"
     }
 }
 
@@ -29,14 +29,14 @@ extension NowPlayingResponseDTO {
                 maximum: dates.maximum
             ),
             page: self.page,
-            totalPage: self.totalPages,
+            totalPage: self.totalPage,
             movies: self.results
                 .map {
                     HomeMovie.Movie(
                         _id: $0.id,
-                        title: $0.title ?? "",
-                        poster: $0.posterPath ?? "",
-                        backdrop: $0.backdropPath ?? ""
+                        title: $0.title,
+                        poster: $0.posterPath,
+                        backdrop: $0.backdropPath
                     )
                 }
         )

--- a/Film-in/Common/Data/DTO/NowPlaying/NowPlayingResponseDTO+Mapping.swift
+++ b/Film-in/Common/Data/DTO/NowPlaying/NowPlayingResponseDTO+Mapping.swift
@@ -11,6 +11,14 @@ struct NowPlayingResponseDTO: Decodable {
     let dates: PeriodResponseDTO
     let page: Int
     let results: [TMDBMovieResponseDTO]
+    let totalPages: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case dates
+        case page
+        case results
+        case totalPages = "total_pages"
+    }
 }
 
 extension NowPlayingResponseDTO {
@@ -21,6 +29,7 @@ extension NowPlayingResponseDTO {
                 maximum: dates.maximum
             ),
             page: self.page,
+            totalPage: self.totalPages,
             movies: self.results
                 .map {
                     HomeMovie.Movie(

--- a/Film-in/Common/Data/DTO/PeopleMovie/PeopleMovieResponseDTO+Mapping.swift
+++ b/Film-in/Common/Data/DTO/PeopleMovie/PeopleMovieResponseDTO+Mapping.swift
@@ -20,9 +20,9 @@ extension PeopleMovieResponseDTO {
                 .map {
                     PersonMovie.Movie(
                         id: $0.id,
-                        title: $0.title ?? "",
-                        poster: $0.posterPath ?? "",
-                        backdrop: $0.backdropPath ?? ""
+                        title: $0.title,
+                        poster: $0.posterPath,
+                        backdrop: $0.backdropPath
                     )
                 }
         )

--- a/Film-in/Common/Data/DTO/Trending/TrendingResponseDTO+Mapping.swift
+++ b/Film-in/Common/Data/DTO/Trending/TrendingResponseDTO+Mapping.swift
@@ -18,9 +18,9 @@ extension TrendingResponseDTO {
                 .map {
                     HomeMovie.Movie(
                         _id: $0.id,
-                        title: $0.title ?? "",
-                        poster: $0.posterPath ?? "",
-                        backdrop: $0.backdropPath ?? ""
+                        title: $0.title,
+                        poster: $0.posterPath,
+                        backdrop: $0.backdropPath
                     )
                 }
         )

--- a/Film-in/Common/Data/DTO/Upcoming/UpcomingResponseDTO+Mapping.swift
+++ b/Film-in/Common/Data/DTO/Upcoming/UpcomingResponseDTO+Mapping.swift
@@ -11,6 +11,14 @@ struct UpcomingResponseDTO: Decodable {
     let dates: PeriodResponseDTO
     let page: Int
     let results: [TMDBMovieResponseDTO]
+    let totalPages: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case dates
+        case page
+        case results
+        case totalPages = "total_pages"
+    }
 }
 
 extension UpcomingResponseDTO {
@@ -21,6 +29,7 @@ extension UpcomingResponseDTO {
                 maximum: dates.maximum
             ),
             page: self.page,
+            totalPage: self.totalPages,
             movies: self.results
                 .map {
                     HomeMovie.Movie(

--- a/Film-in/Common/Data/DTO/Upcoming/UpcomingResponseDTO+Mapping.swift
+++ b/Film-in/Common/Data/DTO/Upcoming/UpcomingResponseDTO+Mapping.swift
@@ -11,13 +11,13 @@ struct UpcomingResponseDTO: Decodable {
     let dates: PeriodResponseDTO
     let page: Int
     let results: [TMDBMovieResponseDTO]
-    let totalPages: Int
+    let totalPage: Int
     
     enum CodingKeys: String, CodingKey {
         case dates
         case page
         case results
-        case totalPages = "total_pages"
+        case totalPage = "total_pages"
     }
 }
 
@@ -29,14 +29,14 @@ extension UpcomingResponseDTO {
                 maximum: dates.maximum
             ),
             page: self.page,
-            totalPage: self.totalPages,
+            totalPage: self.totalPage,
             movies: self.results
                 .map {
                     HomeMovie.Movie(
                         _id: $0.id,
-                        title: $0.title ?? "",
-                        poster: $0.posterPath ?? "",
-                        backdrop: $0.backdropPath ?? ""
+                        title: $0.title,
+                        poster: $0.posterPath,
+                        backdrop: $0.backdropPath
                     )
                 }
         )

--- a/Film-in/Common/Data/TMDBMovieResponseDTO.swift
+++ b/Film-in/Common/Data/TMDBMovieResponseDTO.swift
@@ -8,19 +8,19 @@
 import Foundation
 
 struct TMDBMovieResponseDTO: Decodable {
-    let backdropPath: String? // upcoming에서 없을 수 있음
+    let backdropPath: String // upcoming에서 없을 수 있음
     let id: Int
-    let title: String?
-    let originTitle: String?
+    let title: String
+    let originTitle: String
     let overview: String
-    let posterPath: String?
+    let posterPath: String
     let mediaType: String? // nowPlaying에서 없을 수 있음
     let adult: Bool
     let originLanguage: String
     let genreIds: [Int]
     let popularity: Double
-    let releaseDate: String?
-    let video: Bool?
+    let releaseDate: String
+    let video: Bool
     let voteAverage: Double
     let voteCount: Int
     
@@ -40,5 +40,24 @@ struct TMDBMovieResponseDTO: Decodable {
         case video
         case voteAverage = "vote_average"
         case voteCount = "vote_count"
+    }
+    
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.backdropPath = try container.decodeIfPresent(String.self, forKey: .backdropPath) ?? ""
+        self.id = try container.decode(Int.self, forKey: .id)
+        self.title = try container.decodeIfPresent(String.self, forKey: .title) ?? ""
+        self.originTitle = try container.decodeIfPresent(String.self, forKey: .originTitle) ?? ""
+        self.overview = try container.decode(String.self, forKey: .overview)
+        self.posterPath = try container.decodeIfPresent(String.self, forKey: .posterPath) ?? ""
+        self.mediaType = try container.decodeIfPresent(String.self, forKey: .mediaType)
+        self.adult = try container.decode(Bool.self, forKey: .adult)
+        self.originLanguage = try container.decode(String.self, forKey: .originLanguage)
+        self.genreIds = try container.decode([Int].self, forKey: .genreIds)
+        self.popularity = try container.decode(Double.self, forKey: .popularity)
+        self.releaseDate = try container.decodeIfPresent(String.self, forKey: .releaseDate) ?? ""
+        self.video = try container.decodeIfPresent(Bool.self, forKey: .video) ?? false
+        self.voteAverage = try container.decode(Double.self, forKey: .voteAverage)
+        self.voteCount = try container.decode(Int.self, forKey: .voteCount)
     }
 }


### PR DESCRIPTION
영화 데이터의 현재 page와 전체 page를 if-let 구문을 통해 옵셔널이 언래핑되는 경우
데이터를 업데이트를 해주는 과정에서 확인해보니 바인딩이 되지 않아 내부 코드가 작동되지 않았음
```swift
private func resultHandler(_ result: Result<HomeMovie, TMDBError>, page: Int) {
    switch result {
    case .success(let movies):
        if page == 1 {
            output.movies = movies
        } else {
            output.movies.movies.append(contentsOf: movies.movies)
        }
        
        if let responsePage = movies.page,
           let responseTotalPage = movies.totalPage
        {
            recentPage = responsePage
            isLastPage = responsePage == responseTotalPage
        }
    case .failure(_):
        if !output.isShowAlert { output.isShowAlert = true }
    }
}
```

그 이유는 DTO에서 현재 page는 받아왔지만 전체 page는 받아오지 않아
조건문 내부가 작동하지 않았던 것을 확인. - 해당 부분 수정완료
```swift
struct NowPlayingResponseDTO: Decodable {
    let dates: PeriodResponseDTO
    let page: Int
    let results: [TMDBMovieResponseDTO]
    let totalPage: Int // 추가된 부분
    
    enum CodingKeys: String, CodingKey {
        case dates
        case page
        case results
        case totalPage = "total_pages" // 추가된 부분
    }
}

extension NowPlayingResponseDTO {
    func toEntity() -> HomeMovie {
        return HomeMovie(
            period: .init(
                minimum: dates.minimum,
                maximum: dates.maximum
            ),
            page: self.page,
            totalPage: self.totalPage, // 추가된 부분
            movies: self.results
                .map {
                    HomeMovie.Movie(
                        _id: $0.id,
                        title: $0.title,
                        poster: $0.posterPath,
                        backdrop: $0.backdropPath
                    )
                }
        )
    }
}
```