### PR TITLE
영화 상세뷰에서 포스터 이미지 깨지는 버그 수정

### DIFF
--- a/Film-in/Presentation/Home/Custom/CustomCarousel.swift
+++ b/Film-in/Presentation/Home/Custom/CustomCarousel.swift
@@ -8,12 +8,16 @@
 import SwiftUI
 
 struct SnapCarousel<Content: View, Item: Identifiable>: View {
-    var content: (Item) -> Content
-    var list: [Item]
+    private let content: (Item) -> Content
+    private let list: [Item]
+    private let spacing: CGFloat
+    private let trailingSpace: CGFloat
     
-    var spacing: CGFloat
-    var trailingSpace: CGFloat
-    @Binding var index: Int
+    @Binding private var index: Int
+    
+    // offset
+    @GestureState private var offset: CGFloat = 0
+    @State private var currentIndex = 0
     
     init(spacing: CGFloat = 15, trailingSpace: CGFloat = 100, index: Binding<Int>, items: [Item], @ViewBuilder content: @escaping (Item) -> Content) {
         self.list = items
@@ -22,10 +26,6 @@ struct SnapCarousel<Content: View, Item: Identifiable>: View {
         self._index = index
         self.content = content
     }
-    
-    // offset
-    @GestureState var offset: CGFloat = 0
-    @State private var currentIndex = 0
     
     var body: some View {
         GeometryReader { proxy in

--- a/Film-in/Presentation/Home/HomeView.swift
+++ b/Film-in/Presentation/Home/HomeView.swift
@@ -77,10 +77,10 @@ struct HomeView: View {
             
             let url = URL(string: ImageURL.tmdb(image: movie.poster).urlString)
             PosterImage(url: url, size: posterSize, title: movie.title)
-                .matchedGeometryEffect(id: movie.id, in: namespace)
+                .matchedGeometryEffect(id: movie.id, in: namespace, properties: .frame, isSource: !showDetailView)
                 .onTapGesture {
-                    self.movie = movie
                     withAnimation(.easeInOut) {
+                        self.movie = movie
                         showDetailView = true
                     }
                 }
@@ -100,10 +100,10 @@ struct HomeView: View {
                     PosterImage(url: url, size: CGSize(width: posterSize.width * 0.5, height: posterSize.height * 0.5), title: movie.title)
                         .padding(.bottom, 4)
                         .padding(.horizontal, 8)
-                        .matchedGeometryEffect(id: movie.id, in: namespace)
+                        .matchedGeometryEffect(id: movie.id, in: namespace, properties: .frame, isSource: !showDetailView)
                         .onTapGesture {
-                            self.movie = movie
                             withAnimation(.easeInOut) {
+                                self.movie = movie
                                 showDetailView = true
                             }
                         }
@@ -123,10 +123,10 @@ struct HomeView: View {
                     PosterImage(url: url, size: CGSize(width: posterSize.width * 0.5, height: posterSize.height * 0.5), title: movie.title)
                         .padding(.bottom, 4)
                         .padding(.horizontal, 8)
-                        .matchedGeometryEffect(id: movie.id, in: namespace)
+                        .matchedGeometryEffect(id: movie.id, in: namespace, properties: .frame, isSource: !showDetailView)
                         .onTapGesture {
-                            self.movie = movie
                             withAnimation(.easeInOut) {
+                                self.movie = movie
                                 showDetailView = true
                             }
                         }
@@ -146,10 +146,10 @@ struct HomeView: View {
                     PosterImage(url: url, size: CGSize(width: posterSize.width * 0.5, height: posterSize.height * 0.5), title: movie.title)
                         .padding(.bottom, 4)
                         .padding(.horizontal, 8)
-                        .matchedGeometryEffect(id: movie.id, in: namespace)
+                        .matchedGeometryEffect(id: movie.id, in: namespace, properties: .frame, isSource: !showDetailView)
                         .onTapGesture {
-                            self.movie = movie
                             withAnimation(.easeInOut) {
+                                self.movie = movie
                                 showDetailView = true
                             }
                         }

--- a/Film-in/Presentation/Home/HomeView.swift
+++ b/Film-in/Presentation/Home/HomeView.swift
@@ -14,7 +14,6 @@ struct HomeView: View {
     @State private var showDetailView = false
     @State private var movie: MovieData?
     @State private var posterSize: CGSize = .zero
-    @State private var offset: CGFloat = 0
     
     init(viewModel: HomeViewModel) {
         self._viewModel = StateObject(wrappedValue: viewModel)
@@ -163,7 +162,6 @@ struct HomeView: View {
     private func detailView(by movie: MovieData) -> some View {
         MovieDetailFactory.makeView(
             movie: movie,
-            offset: $offset,
             showDetailView: $showDetailView,
             namespace: namespace,
             posterSize: posterSize

--- a/Film-in/Presentation/MovieDetail/Scene/MovieDetailFactory.swift
+++ b/Film-in/Presentation/MovieDetail/Scene/MovieDetailFactory.swift
@@ -28,7 +28,6 @@ enum MovieDetailFactory {
     
     static func makeView(
         movie: MovieData,
-        offset: Binding<CGFloat>,
         showDetailView: Binding<Bool>,
         namespace: Namespace.ID,
         posterSize: CGSize
@@ -42,7 +41,6 @@ enum MovieDetailFactory {
                 networkMonitor: NetworkMonitor.shared,
                 movieId: movie._id
             ),
-            offset: offset,
             showDetailView: showDetailView,
             namespace: namespace,
             movie: movie,

--- a/Film-in/Presentation/MovieDetail/TransitionMovieDetailView.swift
+++ b/Film-in/Presentation/MovieDetail/TransitionMovieDetailView.swift
@@ -140,7 +140,8 @@ struct TransitionMovieDetailView: View {
         )
         .matchedGeometryEffect(
             id: movie.id,
-            in: namespace, properties: .frame, isSource: showDetailView
+            in: namespace, properties: .frame,
+            isSource: showDetailView
         )
     }
     

--- a/Film-in/Presentation/MovieDetail/TransitionMovieDetailView.swift
+++ b/Film-in/Presentation/MovieDetail/TransitionMovieDetailView.swift
@@ -16,8 +16,9 @@ struct TransitionMovieDetailView: View {
     @State private var isFullOverview: Bool
     @State private var isDateSetup: Bool
     @State private var dateSetupType: DateSetupType
+    @State private var offset: CGFloat
     
-    @Binding var offset: CGFloat
+//    @Binding var offset: CGFloat
     @Binding var showDetailView: Bool
     
     private var namespace: Namespace.ID
@@ -30,7 +31,6 @@ struct TransitionMovieDetailView: View {
         isFullOverview: Bool = false,
         isDateSetup: Bool = false,
         dateSetupType: DateSetupType = .want,
-        offset: Binding<CGFloat>,
         showDetailView: Binding<Bool>,
         namespace: Namespace.ID,
         movie: MovieData,
@@ -40,7 +40,7 @@ struct TransitionMovieDetailView: View {
         self._isFullOverview = State(wrappedValue: isFullOverview)
         self._isDateSetup = State(wrappedValue: isDateSetup)
         self._dateSetupType = State(wrappedValue: dateSetupType)
-        self._offset = offset
+        self._offset = State(wrappedValue: 0.0)
         self._showDetailView = showDetailView
         self.namespace = namespace
         self.movie = movie

--- a/Film-in/Presentation/MovieDetail/TransitionMovieDetailView.swift
+++ b/Film-in/Presentation/MovieDetail/TransitionMovieDetailView.swift
@@ -18,10 +18,9 @@ struct TransitionMovieDetailView: View {
     @State private var dateSetupType: DateSetupType
     @State private var offset: CGFloat
     
-//    @Binding var offset: CGFloat
     @Binding var showDetailView: Bool
     
-    private var namespace: Namespace.ID
+    private let namespace: Namespace.ID
     
     private let movie: MovieData
     private let size: CGSize
@@ -141,7 +140,7 @@ struct TransitionMovieDetailView: View {
         )
         .matchedGeometryEffect(
             id: movie.id,
-            in: namespace
+            in: namespace, properties: .frame, isSource: showDetailView
         )
     }
     


### PR DESCRIPTION
### 원인
matchedGeometryEffect로 인해 홈화면의 포스터 이미지와 상세화면의 포스터 이미지의 정의 불분명해지는 현상이 존재

### 해결
matchedGeometryEffect의 isSource를 활용하여 명확히 정의

```swift
// HOME
PosterImage(url: url, size: posterSize, title: movie.title)
    .matchedGeometryEffect(id: movie.id, in: namespace, properties: .frame, isSource: !showDetailView)

// DETAIL
PosterImage(
    url: url,
    size: CGSize(
        width: size.width * 1.3,
        height: size.height * 1.3),
    title: movie.title
)
.matchedGeometryEffect(
    id: movie.id,
    in: namespace, properties: .frame,
    isSource: showDetailView
)
```