### PR TITLE
FIX: 영화 WANT 날짜 저장완료 시 Modal이 내려가지 않는 버그 수정

### DIFF
--- a/Film-in/Presentation/DateSetup/DateSetupView.swift
+++ b/Film-in/Presentation/DateSetup/DateSetupView.swift
@@ -105,7 +105,3 @@ struct DateSetupView: View {
         }
     }
 }
-
-//#Preview {
-//    DateSetupView(viewModel: DateSetupViewModel(dateSetupService: DefaultDateSetupService(localNotificationManager: DefaultLocalNotificationManager.shared, databaseRepository: RealmRepository.shared), movie: (123, "", "", ""), type: .want), isPresented: .constant(true))
-//}

--- a/Film-in/Presentation/DateSetup/DateSetupViewModel.swift
+++ b/Film-in/Presentation/DateSetup/DateSetupViewModel.swift
@@ -147,6 +147,8 @@ extension DateSetupViewModel {
                         }
                     }
                     .store(in: &cancellable)
+            } else {
+                output.isSuccess = true
             }
         case .watched:
             output.isSuccess = true

--- a/Film-in/Presentation/MovieDetail/MovieDetailView.swift
+++ b/Film-in/Presentation/MovieDetail/MovieDetailView.swift
@@ -93,8 +93,8 @@ struct MovieDetailView: View {
         PosterImage(
             url: url,
             size: CGSize(
-                width: size.width * 1.3,
-                height: size.height * 1.3),
+                width: size.width,
+                height: size.height),
             title: movie.title
         )
     }

--- a/Film-in/Presentation/MovieDetail/TransitionMovieDetailView.swift
+++ b/Film-in/Presentation/MovieDetail/TransitionMovieDetailView.swift
@@ -134,8 +134,8 @@ struct TransitionMovieDetailView: View {
         PosterImage(
             url: url,
             size: CGSize(
-                width: size.width * 1.3,
-                height: size.height * 1.3),
+                width: size.width,
+                height: size.height),
             title: movie.title
         )
         .matchedGeometryEffect(


### PR DESCRIPTION
WANT의 경우 알람으로 설정되어 있을 시에만
성공 케이스를 전달하고 있었음.
알람으로 설정되어 있지 않는 경우에서
성공 케이스를 전달하도록 수정

> 관련 코드
```swift
private func saveMovie() {
    let query = WantWatchedMovieQuery(
        movieId: movie._id,
        title: movie.title,
        backdrop: movie.backdrop,
        poster: movie.poster,
        date: output.selection,
        type: type,
        isAlarm: output.isAlarm
    )
    
    dateSetupService.saveWantOrWatchedMovie(query: query)
    
    switch type {
    case .want:
        if output.isAlarm {
            let publisher = dateSetupService.registPushAlarm(
                movie: (movie._id, movie.title),
                date: output.selection
            )
            publisher
                .receive(on: DispatchQueue.main)
                .sink { [weak self] result in
                    guard let self else { return }
                    switch result {
                    case .success():
                        output.isSuccess = true
                    case .failure(_):
                        output.isSuccess = false
                        output.isError = true
                    }
                }
                .store(in: &cancellable)
        } else {
            output.isSuccess = true
        }
    case .watched:
        output.isSuccess = true
    }
}
```