### PR TITLE
리팩토링 - 이미지 다운샘플링

### DIFF
--- a/Film-in/Common/Reusable/PosterImageView.swift
+++ b/Film-in/Common/Reusable/PosterImageView.swift
@@ -6,24 +6,86 @@
 //
 
 import SwiftUI
+import ImageIO
 import Kingfisher
 
 struct PosterImage: View {
     let url: URL?
     let size: CGSize
     let title: String
+    let isDownsampling: Bool
     
     var body: some View {
-        KFImage(url)
-            .resizable()
-            .placeholder{
-                Text(title)
-                    .foregroundStyle(.appText)
-            }
-            .cancelOnDisappear(true)
-            .fade(duration: 0.25)
-            .aspectRatio(contentMode: .fill)
-            .frame(width: size.width, height: size.height)
-            .clipped()
+        if isDownsampling {
+            KFImage(url)
+                .resizable()
+                .setProcessor(DownsampleProcessor(pointSize: size))
+                .placeholder{
+                    Text(title)
+                        .foregroundStyle(.appText)
+                }
+                .cacheOriginalImage()
+                .cancelOnDisappear(true)
+                .fade(duration: 0.25)
+                .aspectRatio(contentMode: .fill)
+                .frame(width: size.width, height: size.height)
+                .clipped()
+        } else {
+            KFImage(url)
+                .resizable()
+                .placeholder{
+                    Text(title)
+                        .foregroundStyle(.appText)
+                }
+                .cacheOriginalImage()
+                .cancelOnDisappear(true)
+                .fade(duration: 0.25)
+                .aspectRatio(contentMode: .fill)
+                .frame(width: size.width, height: size.height)
+                .clipped()
+        }
+    }
+}
+
+struct DownsampleProcessor: ImageProcessor {
+    let identifier: String
+    let pointSize: CGSize
+    
+    init(pointSize: CGSize) {
+        self.identifier = "com.example.DownsampleProcessor.\(pointSize)"
+        self.pointSize = pointSize
+    }
+
+    func process(item: ImageProcessItem, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {
+        switch item {
+        case .image(let image):
+            guard let data = image.pngData() else { return nil }
+            return downsampling(data: data, pointSize: pointSize, scale: UITraitCollection.current.displayScale)
+        case .data(let data):
+            return downsampling(data: data, pointSize: pointSize, scale: UITraitCollection.current.displayScale)
+        }
+    }
+
+    private func downsampling(data: Data, pointSize: CGSize, scale: CGFloat) -> KFCrossPlatformImage? {
+        let imageSourceOption = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let imageSource = CGImageSourceCreateWithData(data as CFData, imageSourceOption) else {
+            print("\(#function) -> imageSource exit")
+            return nil
+        }
+        
+        let maxDimensionsInPixels = max(pointSize.width, pointSize.height) * scale
+        let downsampleOptions = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxDimensionsInPixels
+        ] as CFDictionary
+        
+        guard let downsampledImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, downsampleOptions) else {
+            print("\(#function) -> downsampledImage exit")
+            return nil
+        }
+        
+        return UIImage(cgImage: downsampledImage)
     }
 }

--- a/Film-in/Presentation/Home/HomeView.swift
+++ b/Film-in/Presentation/Home/HomeView.swift
@@ -76,7 +76,7 @@ struct HomeView: View {
         SnapCarousel(spacing: 28, trailingSpace: 120, index: $index, items: viewModel.output.trendingMovies.movies) { movie in
             
             let url = URL(string: ImageURL.tmdb(image: movie.poster).urlString)
-            PosterImage(url: url, size: posterSize, title: movie.title)
+            PosterImage(url: url, size: posterSize, title: movie.title, isDownsampling: true)
                 .matchedGeometryEffect(id: movie.id, in: namespace, properties: .frame, isSource: !showDetailView)
                 .onTapGesture {
                     withAnimation(.easeInOut) {
@@ -97,7 +97,7 @@ struct HomeView: View {
             LazyHStack {
                 ForEach(viewModel.output.nowPlayingMovies.movies, id: \.id) { movie in
                     let url = URL(string: ImageURL.tmdb(image: movie.poster).urlString)
-                    PosterImage(url: url, size: CGSize(width: posterSize.width * 0.5, height: posterSize.height * 0.5), title: movie.title)
+                    PosterImage(url: url, size: CGSize(width: posterSize.width * 0.5, height: posterSize.height * 0.5), title: movie.title, isDownsampling: true)
                         .padding(.bottom, 4)
                         .padding(.horizontal, 8)
                         .matchedGeometryEffect(id: movie.id, in: namespace, properties: .frame, isSource: !showDetailView)
@@ -120,7 +120,7 @@ struct HomeView: View {
             LazyHStack {
                 ForEach(viewModel.output.upcomingMovies.movies, id: \.id) { movie in
                     let url = URL(string: ImageURL.tmdb(image: movie.poster).urlString)
-                    PosterImage(url: url, size: CGSize(width: posterSize.width * 0.5, height: posterSize.height * 0.5), title: movie.title)
+                    PosterImage(url: url, size: CGSize(width: posterSize.width * 0.5, height: posterSize.height * 0.5), title: movie.title, isDownsampling: true)
                         .padding(.bottom, 4)
                         .padding(.horizontal, 8)
                         .matchedGeometryEffect(id: movie.id, in: namespace, properties: .frame, isSource: !showDetailView)
@@ -143,7 +143,7 @@ struct HomeView: View {
             LazyHStack {
                 ForEach(viewModel.output.recommendMovies.movies, id: \.id) { movie in
                     let url = URL(string: ImageURL.tmdb(image: movie.poster).urlString)
-                    PosterImage(url: url, size: CGSize(width: posterSize.width * 0.5, height: posterSize.height * 0.5), title: movie.title)
+                    PosterImage(url: url, size: CGSize(width: posterSize.width * 0.5, height: posterSize.height * 0.5), title: movie.title, isDownsampling: true)
                         .padding(.bottom, 4)
                         .padding(.horizontal, 8)
                         .matchedGeometryEffect(id: movie.id, in: namespace, properties: .frame, isSource: !showDetailView)

--- a/Film-in/Presentation/MovieDetail/MovieDetailView.swift
+++ b/Film-in/Presentation/MovieDetail/MovieDetailView.swift
@@ -95,7 +95,8 @@ struct MovieDetailView: View {
             size: CGSize(
                 width: size.width,
                 height: size.height),
-            title: movie.title
+            title: movie.title,
+            isDownsampling: true
         )
     }
     
@@ -184,7 +185,8 @@ struct MovieDetailView: View {
                             PosterImage(
                                 url: url,
                                 size: CGSize(width: 90, height: 90),
-                                title: person.name.replacingOccurrences(of: " ", with: "\n")
+                                title: person.name.replacingOccurrences(of: " ", with: "\n"),
+                                isDownsampling: true
                             )
                             .clipShape(Circle())
                             .grayscale(colorScheme == .dark ? 1 : 0)
@@ -275,7 +277,8 @@ struct MovieDetailView: View {
                                 width: size.width * 0.5,
                                 height: size.height * 0.5
                             ),
-                            title: similar.title
+                            title: similar.title,
+                            isDownsampling: true
                         )
                         .padding(.horizontal, 8)
                     }
@@ -298,7 +301,8 @@ struct MovieDetailView: View {
                             width: size.height * 0.4 * backdrop.ratio,
                             height: size.height * 0.4
                         ),
-                        title: ""
+                        title: "",
+                        isDownsampling: true
                     )
                     .padding(.horizontal, 8)
                 }
@@ -320,7 +324,8 @@ struct MovieDetailView: View {
                             width: Double(poster.width) * 0.1,
                             height: Double(poster.height) * 0.1
                         ),
-                        title: ""
+                        title: "",
+                        isDownsampling: true
                     )
                     .padding(.horizontal, 8)
                 }

--- a/Film-in/Presentation/MovieDetail/TransitionMovieDetailView.swift
+++ b/Film-in/Presentation/MovieDetail/TransitionMovieDetailView.swift
@@ -136,7 +136,8 @@ struct TransitionMovieDetailView: View {
             size: CGSize(
                 width: size.width,
                 height: size.height),
-            title: movie.title
+            title: movie.title,
+            isDownsampling: true
         )
         .matchedGeometryEffect(
             id: movie.id,
@@ -230,7 +231,8 @@ struct TransitionMovieDetailView: View {
                             PosterImage(
                                 url: url,
                                 size: CGSize(width: 90, height: 90),
-                                title: person.name.replacingOccurrences(of: " ", with: "\n")
+                                title: person.name.replacingOccurrences(of: " ", with: "\n"),
+                                isDownsampling: true
                             )
                             .clipShape(Circle())
                             .grayscale(colorScheme == .dark ? 1 : 0)
@@ -323,7 +325,8 @@ struct TransitionMovieDetailView: View {
                                 width: size.width * 0.5,
                                 height: size.height * 0.5
                             ),
-                            title: similar.title
+                            title: similar.title,
+                            isDownsampling: true
                         )
                         .padding(.horizontal, 8)
                     }
@@ -346,7 +349,8 @@ struct TransitionMovieDetailView: View {
                             width: size.height * 0.4 * backdrop.ratio,
                             height: size.height * 0.4
                         ),
-                        title: ""
+                        title: "",
+                        isDownsampling: true
                     )
                     .padding(.horizontal, 8)
                 }
@@ -368,7 +372,8 @@ struct TransitionMovieDetailView: View {
                             width: Double(poster.width) * 0.1,
                             height: Double(poster.height) * 0.1
                         ),
-                        title: ""
+                        title: "",
+                        isDownsampling: true
                     )
                     .padding(.horizontal, 8)
                 }

--- a/Film-in/Presentation/MovieListView/MovieListView.swift
+++ b/Film-in/Presentation/MovieListView/MovieListView.swift
@@ -76,7 +76,8 @@ struct MovieListView: View {
                     PosterImage(
                         url: url,
                         size: CGSize(width: width, height: height),
-                        title: movie.title
+                        title: movie.title,
+                        isDownsampling: true
                     )
                     .padding(.bottom, 4)
                     .padding(.horizontal, 8)

--- a/Film-in/Presentation/MyView/MyView.swift
+++ b/Film-in/Presentation/MyView/MyView.swift
@@ -81,7 +81,8 @@ struct MyView: View {
                         width: proxy.size.width - 40,
                         height: (proxy.size.width - 40) * 0.56
                     ),
-                    title: movie.title
+                    title: movie.title,
+                    isDownsampling: true
                 )
                 .overlay(alignment: .bottom) {
                     Rectangle()
@@ -129,7 +130,8 @@ struct MyView: View {
                         width: proxy.size.width - 40,
                         height: (proxy.size.width - 40) * 0.56
                     ),
-                    title: movie.title
+                    title: movie.title,
+                    isDownsampling: true
                 )
                 .overlay(alignment: .bottom) {
                     Rectangle()

--- a/Film-in/Presentation/PersonDetail/PersonDetailView.swift
+++ b/Film-in/Presentation/PersonDetail/PersonDetailView.swift
@@ -67,7 +67,8 @@ struct PersonDetailView: View {
         PosterImage(
             url: url,
             size: CGSize(width: width, height: width * 1.5),
-            title: viewModel.output.personDetail.name
+            title: viewModel.output.personDetail.name,
+            isDownsampling: false
         )
         .grayscale(colorScheme == .dark ? 1 : 0)
     }
@@ -102,7 +103,8 @@ struct PersonDetailView: View {
                     PosterImage(
                         url: url,
                         size: size,
-                        title: movie.title
+                        title: movie.title,
+                        isDownsampling: true
                     )
                     .padding(.bottom, 4)
                     .padding(.horizontal, 8)


### PR DESCRIPTION
이미지의 용량을 줄이기 위해 다운샘플링을 진행

> 참고
> [WWDC 2018 Image and Graphics Best Practices](https://nonstrict.eu/wwdcindex/wwdc2018/219/)

- 관련코드
```swift
import SwiftUI
import ImageIO
import Kingfisher

struct PosterImage: View {
    let url: URL?
    let size: CGSize
    let title: String
    let isDownsampling: Bool
    
    var body: some View {
        if isDownsampling {
            KFImage(url)
                .resizable()
                .setProcessor(DownsampleProcessor(pointSize: size))
                .placeholder{
                    Text(title)
                        .foregroundStyle(.appText)
                }
                .cacheOriginalImage()
                .cancelOnDisappear(true)
                .fade(duration: 0.25)
                .aspectRatio(contentMode: .fill)
                .frame(width: size.width, height: size.height)
                .clipped()
        } else {
            KFImage(url)
                .resizable()
                .placeholder{
                    Text(title)
                        .foregroundStyle(.appText)
                }
                .cacheOriginalImage()
                .cancelOnDisappear(true)
                .fade(duration: 0.25)
                .aspectRatio(contentMode: .fill)
                .frame(width: size.width, height: size.height)
                .clipped()
        }
    }
}

struct DownsampleProcessor: ImageProcessor {
    let identifier: String
    let pointSize: CGSize
    
    init(pointSize: CGSize) {
        self.identifier = "com.example.DownsampleProcessor.\(pointSize)"
        self.pointSize = pointSize
    }

    func process(item: ImageProcessItem, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {
        switch item {
        case .image(let image):
            guard let data = image.pngData() else { return nil }
            return downsampling(data: data, pointSize: pointSize, scale: UITraitCollection.current.displayScale)
        case .data(let data):
            return downsampling(data: data, pointSize: pointSize, scale: UITraitCollection.current.displayScale)
        }
    }

    private func downsampling(data: Data, pointSize: CGSize, scale: CGFloat) -> KFCrossPlatformImage? {
        let imageSourceOption = [kCGImageSourceShouldCache: false] as CFDictionary
        guard let imageSource = CGImageSourceCreateWithData(data as CFData, imageSourceOption) else {
            print("\(#function) -> imageSource exit")
            return nil
        }
        
        let maxDimensionsInPixels = max(pointSize.width, pointSize.height) * scale
        let downsampleOptions = [
            kCGImageSourceCreateThumbnailFromImageAlways: true,
            kCGImageSourceShouldCacheImmediately: true,
            kCGImageSourceCreateThumbnailWithTransform: true,
            kCGImageSourceThumbnailMaxPixelSize: maxDimensionsInPixels
        ] as CFDictionary
        
        guard let downsampledImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, downsampleOptions) else {
            print("\(#function) -> downsampledImage exit")
            return nil
        }
        
        return UIImage(cgImage: downsampledImage)
    }
}
```